### PR TITLE
Implement deterministic cycle payouts with rollover tracking

### DIFF
--- a/questchores/src/App.tsx
+++ b/questchores/src/App.tsx
@@ -10,6 +10,8 @@ import { AppState, Chore, Completion, CycleConfig, User } from './lib/models';
 import { todayISO, dayIndex, withinCycle, cycleDayLabel } from './lib/dates';
 import { allocateForDate } from './lib/allocation';
 import { planDailyAllocation } from './lib/simulate';
+import TodayChoreList from './components/TodayChoreList';
+import { completeDailyChore, generateCycle, rolloverUnearned } from './lib/cycles';
 
 const id = () => (typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : Math.random().toString(36).slice(2));
 
@@ -31,14 +33,25 @@ export default function App() {
     setSelectedDate((prev) => prev || state.config.startDateISO || todayISO());
   }, [state.config.startDateISO]);
 
+  useEffect(() => {
+    if (!state.currentCycle) {
+      setState((prev) => {
+        if (prev.currentCycle) return prev;
+        const generated = generateCycle(prev);
+        return { ...prev, ...generated };
+      });
+    }
+  }, [state.currentCycle, setState]);
+
   const updateConfig = (config: CycleConfig) => {
     setState((prev) => ({ ...prev, config }));
   };
 
   const remainingPool = useMemo(() => {
     const paid = state.payouts.filter((p) => withinCycle(p.dateISO, state.config)).reduce((sum, p) => sum + p.amount, 0);
-    return Math.max(0, state.config.cashPoolTotal - paid);
-  }, [state.payouts, state.config]);
+    const funding = state.currentCycle?.fundingPool ?? state.config.cashPoolTotal;
+    return Math.max(0, funding - paid);
+  }, [state.payouts, state.config, state.currentCycle]);
 
   const cycleStatus = cycleDayLabel(selectedDate, state.config);
 
@@ -122,18 +135,49 @@ export default function App() {
 
   const resetCycle = () => {
     const freshUsers = state.users.map((u) => ({ ...u, totalEarned: 0, totalCashedOut: 0 }));
-    setState((prev) => ({
-      ...defaultState,
-      users: freshUsers,
-      chores: prev.chores,
-      config: { ...prev.config, startDateISO: todayISO() },
-    } as AppState));
+    setState((prev) => {
+      const nextConfig = { ...prev.config, startDateISO: todayISO() };
+      const base: AppState = {
+        ...prev,
+        users: freshUsers,
+        config: nextConfig,
+        completions: [],
+        payouts: [],
+        dailyChores: [],
+        dailyRollovers: prev.dailyRollovers,
+      } as AppState;
+      const generated = generateCycle(base, nextConfig, nextConfig.startDateISO);
+      return { ...base, ...generated };
+    });
     setSelectedDate(todayISO());
+  };
+
+  const completeTodayChore = (dailyChoreId: string) => {
+    setState((prev) => ({
+      ...prev,
+      dailyChores: completeDailyChore(prev.dailyChores, dailyChoreId, new Date()),
+    }));
+  };
+
+  const recordRollover = (dateISO: string) => {
+    setState((prev) => {
+      if (!prev.currentCycle) return prev;
+      const result = rolloverUnearned(prev.currentCycle, prev.dailyChores, prev.dailyRollovers, dateISO, new Date());
+      if (result.rollovers === prev.dailyRollovers) return prev;
+      return { ...prev, currentCycle: result.cycle, dailyRollovers: result.rollovers };
+    });
   };
 
   const importState = (next: AppState) => {
     if (!next || typeof next !== 'object') return;
-    setState({ ...defaultState, ...next, config: { ...defaultState.config, ...next.config } });
+    setState({
+      ...defaultState,
+      ...next,
+      config: { ...defaultState.config, ...next.config },
+      currentCycle: next.currentCycle ?? null,
+      dailyChores: next.dailyChores ?? [],
+      dailyRollovers: next.dailyRollovers ?? [],
+    });
   };
 
   const plan = planDailyAllocation(state, selectedDate);
@@ -145,10 +189,12 @@ export default function App() {
             <h1 className="text-2xl font-bold tracking-tight">QuestChores</h1>
             <p className="text-sm text-slate-300">{cycleStatus}</p>
           </div>
-          <div className="text-sm text-slate-300">
+          <div className="text-sm text-slate-300 text-right">
             Remaining Pool: <span className="text-amber-300">${remainingPool.toFixed(2)}</span>
             <br />
             Today's plan: ${plan.totalFinal.toFixed(2)} across {plan.entries.length} quests
+            <br />
+            Rollover pool: <span className="text-sky-300">${(state.currentCycle?.rolloverPool ?? 0).toFixed(2)}</span>
           </div>
         </div>
       </header>
@@ -180,9 +226,19 @@ export default function App() {
           completions={state.completions}
           payouts={state.payouts}
           config={state.config}
+          currentCycle={state.currentCycle}
           onAddCompletion={addCompletion}
           onRemoveCompletion={removeCompletion}
           onAllocate={allocate}
+        />
+        <TodayChoreList
+          dateISO={selectedDate}
+          baseChores={state.chores}
+          dailyChores={state.dailyChores}
+          currentCycle={state.currentCycle}
+          rollovers={state.dailyRollovers}
+          onComplete={completeTodayChore}
+          onRecordRollover={recordRollover}
         />
         <ImportExport state={state} onImport={importState} />
       </main>

--- a/questchores/src/components/DayView.tsx
+++ b/questchores/src/components/DayView.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react';
-import { Chore, Completion, CycleConfig, Payout, User } from '../lib/models';
+import { Chore, Completion, CycleConfig, CycleState, Payout, User } from '../lib/models';
 import { planDailyAllocation } from '../lib/simulate';
 import { cycleDayLabel } from '../lib/dates';
 
@@ -11,6 +11,7 @@ type Props = {
   completions: Completion[];
   payouts: Payout[];
   config: CycleConfig;
+  currentCycle: CycleState | null;
   onAddCompletion: (userId: string, choreId: string, dateISO: string) => void;
   onRemoveCompletion: (id: string) => void;
   onAllocate: (dateISO: string) => void;
@@ -24,6 +25,7 @@ export default function DayView({
   completions,
   payouts,
   config,
+  currentCycle,
   onAddCompletion,
   onRemoveCompletion,
   onAllocate,
@@ -32,8 +34,21 @@ export default function DayView({
   const dayPayouts = payouts.filter((p) => p.dateISO === dateISO);
 
   const plan = useMemo(
-    () => planDailyAllocation({ users, chores, completions, payouts, config }, dateISO),
-    [users, chores, completions, payouts, config, dateISO]
+    () =>
+      planDailyAllocation(
+        {
+          users,
+          chores,
+          completions,
+          payouts,
+          config,
+          currentCycle,
+          dailyChores: [],
+          dailyRollovers: [],
+        },
+        dateISO
+      ),
+    [users, chores, completions, payouts, config, currentCycle, dateISO]
   );
 
   const choreMap = new Map(chores.map((c) => [c.id, c]));

--- a/questchores/src/components/TodayChoreList.tsx
+++ b/questchores/src/components/TodayChoreList.tsx
@@ -1,0 +1,94 @@
+import { Chore, CycleState, DailyChore, DailyRollover } from '../lib/models';
+import { todayISO } from '../lib/dates';
+import { isCompletedToday } from '../lib/cycles';
+
+const today = todayISO();
+
+type Props = {
+  dateISO: string;
+  baseChores: Chore[];
+  dailyChores: DailyChore[];
+  currentCycle: CycleState | null;
+  rollovers: DailyRollover[];
+  onComplete: (id: string) => void;
+  onRecordRollover: (date: string) => void;
+};
+
+export default function TodayChoreList({
+  dateISO,
+  baseChores,
+  dailyChores,
+  currentCycle,
+  rollovers,
+  onComplete,
+  onRecordRollover,
+}: Props) {
+  const choresForDate = dailyChores.filter((chore) => chore.scheduledDate === dateISO);
+  const baseMap = new Map(baseChores.map((chore) => [chore.id, chore]));
+  const totalAvailable = choresForDate.reduce((sum, chore) => sum + chore.finalPayout, 0);
+  const unearned = choresForDate
+    .filter((chore) => chore.status !== 'completed')
+    .reduce((sum, chore) => sum + chore.finalPayout, 0);
+  const rolloverLogged = rollovers.some((entry) => entry.cycleId === currentCycle?.id && entry.date === dateISO);
+
+  return (
+    <section className="bg-slate-800/60 rounded-lg p-4 space-y-4">
+      <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h2 className="text-lg font-semibold">Today's Chores</h2>
+          <p className="text-sm text-slate-300">{dateISO === today ? 'Today' : dateISO}</p>
+        </div>
+        <div className="text-sm text-slate-200 flex flex-col gap-1 text-right">
+          <span>
+            Today's total available: <span className="text-amber-300">${totalAvailable.toFixed(2)}</span>
+          </span>
+          <span>
+            Unearned so far: <span className="text-rose-300">${unearned.toFixed(2)}</span>
+          </span>
+          <button
+            className="self-end px-3 py-1 rounded bg-slate-700 hover:bg-slate-600 disabled:opacity-50 disabled:cursor-not-allowed"
+            onClick={() => onRecordRollover(dateISO)}
+            disabled={!currentCycle || rolloverLogged}
+          >
+            {rolloverLogged ? 'Rollover recorded' : 'Record rollover'}
+          </button>
+        </div>
+      </header>
+      <div className="space-y-2">
+        {choresForDate.length === 0 && (
+          <p className="text-sm text-slate-400">No chores scheduled for this date.</p>
+        )}
+        {choresForDate.map((chore) => {
+          const base = baseMap.get(chore.choreId);
+          const completed = chore.status === 'completed';
+          const completedToday = chore.completedAt
+            ? isCompletedToday(chore, dateISO)
+            : false;
+          return (
+            <div
+              key={chore.id}
+              className={`flex items-center justify-between rounded px-3 py-2 border border-slate-700 bg-slate-900/40 transition ${
+                completed ? 'opacity-60 pointer-events-none' : 'hover:bg-slate-900/60'
+              }`}
+            >
+              <div>
+                <div className="font-medium text-sm">{base?.title ?? 'Chore'}</div>
+                <div className="text-xs text-slate-400">Payout: ${chore.finalPayout.toFixed(2)}</div>
+                {completed && completedToday && (
+                  <div className="text-xs text-emerald-400 mt-1">Completed</div>
+                )}
+              </div>
+              <button
+                className="px-3 py-1 rounded bg-emerald-500 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                onClick={() => onComplete(chore.id)}
+                disabled={completed}
+              >
+                {completed ? 'Done' : 'Complete'}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/questchores/src/lib/cycles.ts
+++ b/questchores/src/lib/cycles.ts
@@ -1,0 +1,158 @@
+import {
+  AppState,
+  Chore,
+  CycleConfig,
+  CycleState,
+  DailyChore,
+  DailyRollover,
+} from './models';
+import { addDays, todayISO, toDateOnlyISO } from './dates';
+import { hashToSeed, mulberry32 } from './rng';
+
+const VARIANCE = 0.1;
+
+const runtimeCrypto: typeof crypto | undefined =
+  typeof globalThis !== 'undefined' && 'crypto' in globalThis ? (globalThis.crypto as typeof crypto) : undefined;
+
+function createId(): string {
+  if (runtimeCrypto && 'randomUUID' in runtimeCrypto) {
+    return runtimeCrypto.randomUUID();
+  }
+  return `chore_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function round2(value: number) {
+  return Math.round(value * 100) / 100;
+}
+
+function recurrenceAllows(chore: Chore, dayIndex: number): boolean {
+  switch (chore.recurrence) {
+    case 'daily':
+      return true;
+    case 'weekly':
+      return dayIndex % 7 === 0;
+    default:
+      return true;
+  }
+}
+
+function makeCycleId(seed: string, start: string) {
+  return `${seed}-${start}`;
+}
+
+export function generateCycle(
+  state: AppState,
+  config: CycleConfig = state.config,
+  startDateISO: string = config.startDateISO || todayISO()
+): Pick<AppState, 'currentCycle' | 'dailyChores'> {
+  const prior = state.currentCycle;
+  const rolloverFromPrior = prior?.rolloverPool ?? 0;
+  const fundingPool = round2(config.cashPoolTotal + rolloverFromPrior);
+  const startDate = toDateOnlyISO(new Date(startDateISO));
+  const endDate = toDateOnlyISO(addDays(new Date(startDate), config.cycleDays - 1));
+  const seed = config.seed || 'cycle';
+  const cycleId = makeCycleId(seed, startDate);
+
+  const cycle: CycleState = {
+    id: cycleId,
+    startDateISO: startDate,
+    endDateISO: endDate,
+    fundingPool,
+    rolloverFromPrior: rolloverFromPrior,
+    rolloverPool: 0,
+    seed,
+  };
+
+  const activeChores = state.chores.filter((chore) => chore.active);
+  const generatorSeed = hashToSeed(`${cycle.seed}|${cycle.id}`);
+  const rng = mulberry32(generatorSeed);
+
+  const dailyChores: DailyChore[] = [];
+  for (let day = 0; day < config.cycleDays; day += 1) {
+    const scheduledDate = toDateOnlyISO(addDays(new Date(startDate), day));
+    for (const chore of activeChores) {
+      if (!recurrenceAllows(chore, day)) continue;
+      const base = chore.mode;
+      const variance = (rng() * 2 - 1) * VARIANCE;
+      const payout = round2(clamp(base * (1 + variance), chore.min, chore.max));
+      dailyChores.push({
+        id: createId(),
+        cycleId: cycle.id,
+        choreId: chore.id,
+        scheduledDate,
+        status: 'pending',
+        finalPayout: payout,
+      });
+    }
+  }
+
+  return { currentCycle: cycle, dailyChores };
+}
+
+export function completeDailyChore(
+  chores: DailyChore[],
+  choreId: string,
+  completedAt: Date = new Date()
+): DailyChore[] {
+  return chores.map((chore) =>
+    chore.id === choreId
+      ? {
+          ...chore,
+          status: 'completed',
+          completedAt: new Date(completedAt).toISOString(),
+        }
+      : chore
+  );
+}
+
+export function choresForDate(chores: DailyChore[], dateISO: string) {
+  return chores.filter((chore) => chore.scheduledDate === dateISO);
+}
+
+export function isCompletedToday(chore: DailyChore, today: string) {
+  if (chore.status !== 'completed' || !chore.completedAt) return false;
+  return toDateOnlyISO(new Date(chore.completedAt)) === today;
+}
+
+export function rolloverUnearned(
+  cycle: CycleState,
+  chores: DailyChore[],
+  rollovers: DailyRollover[],
+  dateISO: string,
+  now: Date = new Date()
+): { cycle: CycleState; rollovers: DailyRollover[] } {
+  const exists = rollovers.some((entry) => entry.cycleId === cycle.id && entry.date === dateISO);
+  if (exists) {
+    return { cycle, rollovers };
+  }
+  const unearned = chores
+    .filter((chore) => chore.scheduledDate === dateISO && chore.status !== 'completed')
+    .reduce((sum, chore) => sum + chore.finalPayout, 0);
+  if (unearned === 0) {
+    const entry: DailyRollover = {
+      cycleId: cycle.id,
+      date: dateISO,
+      unearnedAmount: 0,
+      createdAt: new Date(now).toISOString(),
+    };
+    return {
+      cycle,
+      rollovers: [...rollovers, entry],
+    };
+  }
+  const entry: DailyRollover = {
+    cycleId: cycle.id,
+    date: dateISO,
+    unearnedAmount: round2(unearned),
+    createdAt: new Date(now).toISOString(),
+  };
+  return {
+    cycle: { ...cycle, rolloverPool: round2(cycle.rolloverPool + entry.unearnedAmount) },
+    rollovers: [...rollovers, entry],
+  };
+}
+

--- a/questchores/src/lib/dates.ts
+++ b/questchores/src/lib/dates.ts
@@ -6,6 +6,13 @@ export function toDateOnlyISO(date: Date): string {
   return d.toISOString().slice(0, 10);
 }
 
+export function addDays(date: Date, days: number): Date {
+  const next = new Date(date);
+  next.setDate(next.getDate() + days);
+  next.setHours(0, 0, 0, 0);
+  return next;
+}
+
 export function dayIndex(dateISO: string, config: CycleConfig): number {
   const start = new Date(config.startDateISO);
   const target = new Date(dateISO);

--- a/questchores/src/lib/models.ts
+++ b/questchores/src/lib/models.ts
@@ -1,4 +1,5 @@
 export type User = { id: string; name: string; totalEarned: number; totalCashedOut: number };
+
 export type Chore = {
   id: string;
   title: string;
@@ -8,18 +9,53 @@ export type Chore = {
   max: number;
   active: boolean;
 };
+
 export type CycleConfig = {
   cycleDays: number;
   cashPoolTotal: number;
   startDateISO: string;
   seed: string;
 };
+
 export type Completion = { id: string; userId: string; choreId: string; dateISO: string };
 export type Payout = { completionId: string; amount: number; dateISO: string };
+
+export type DailyChoreStatus = 'pending' | 'completed';
+
+export type CycleState = {
+  id: string;
+  startDateISO: string;
+  endDateISO: string;
+  fundingPool: number;
+  rolloverFromPrior: number;
+  rolloverPool: number;
+  seed: string;
+};
+
+export type DailyChore = {
+  id: string;
+  cycleId: string;
+  choreId: string;
+  scheduledDate: string;
+  status: DailyChoreStatus;
+  completedAt?: string;
+  finalPayout: number;
+};
+
+export type DailyRollover = {
+  cycleId: string;
+  date: string;
+  unearnedAmount: number;
+  createdAt: string;
+};
+
 export type AppState = {
   users: User[];
   chores: Chore[];
   config: CycleConfig;
   completions: Completion[];
   payouts: Payout[];
+  currentCycle: CycleState | null;
+  dailyChores: DailyChore[];
+  dailyRollovers: DailyRollover[];
 };

--- a/questchores/src/lib/simulate.ts
+++ b/questchores/src/lib/simulate.ts
@@ -33,7 +33,7 @@ function sumPayouts(payouts: Payout[], predicate: (p: Payout) => boolean) {
 }
 
 export function planDailyAllocation(state: AppState, dateISO: string): AllocationPlan {
-  const { config, completions, chores, payouts } = state;
+  const { config, completions, chores, payouts, currentCycle } = state;
   if (!config.startDateISO) {
     return { dailyBudget: 0, remainingPool: config.cashPoolTotal, remainingDays: 0, totalSuggested: 0, totalFinal: 0, entries: [] };
   }
@@ -43,7 +43,8 @@ export function planDailyAllocation(state: AppState, dateISO: string): Allocatio
   }
 
   const payoutsBefore = sumPayouts(payouts, (p) => withinCycle(p.dateISO, config) && dayIndex(p.dateISO, config) < idx);
-  const remainingPool = Math.max(0, config.cashPoolTotal - payoutsBefore);
+  const fundingPool = currentCycle?.fundingPool ?? config.cashPoolTotal;
+  const remainingPool = Math.max(0, fundingPool - payoutsBefore);
   const remainingDays = Math.max(1, config.cycleDays - idx);
   const dailyBudget = floor2(remainingPool / remainingDays);
 

--- a/questchores/src/lib/storage.ts
+++ b/questchores/src/lib/storage.ts
@@ -9,6 +9,9 @@ const defaultState: AppState = {
   chores: [],
   completions: [],
   payouts: [],
+  currentCycle: null,
+  dailyChores: [],
+  dailyRollovers: [],
   config: {
     cycleDays: 28,
     cashPoolTotal: 400,

--- a/questchores/tests/allocation.test.ts
+++ b/questchores/tests/allocation.test.ts
@@ -16,6 +16,9 @@ const baseState: AppState = {
     { id: 'k2', userId: 'u2', choreId: 'c2', dateISO: '2024-01-01' },
   ],
   payouts: [],
+  currentCycle: null,
+  dailyChores: [],
+  dailyRollovers: [],
   config: {
     cycleDays: 10,
     cashPoolTotal: 100,

--- a/questchores/tests/cycles.test.ts
+++ b/questchores/tests/cycles.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { generateCycle, completeDailyChore, rolloverUnearned, isCompletedToday } from '../src/lib/cycles';
+import { AppState, CycleState } from '../src/lib/models';
+
+const baseState: AppState = {
+  users: [],
+  chores: [
+    { id: 'chore1', title: 'Dishes', recurrence: 'daily', min: 9, mode: 10, max: 12, active: true },
+  ],
+  completions: [],
+  payouts: [],
+  currentCycle: null,
+  dailyChores: [],
+  dailyRollovers: [],
+  config: {
+    cycleDays: 3,
+    cashPoolTotal: 60,
+    startDateISO: '2024-03-09',
+    seed: 'home-seed',
+  },
+};
+
+describe('cycle generation and rollovers', () => {
+  it('keeps payouts immutable after completion', () => {
+    const { dailyChores } = generateCycle(baseState);
+    const target = dailyChores[0];
+    const completed = completeDailyChore(dailyChores, target.id, new Date('2024-03-09T23:59:59Z'));
+    const after = completed.find((entry) => entry.id === target.id)!;
+    expect(after.finalPayout).toBe(target.finalPayout);
+  });
+
+  it('schedules dates correctly across DST transitions', () => {
+    const { dailyChores } = generateCycle({
+      ...baseState,
+      config: { ...baseState.config, cycleDays: 2, startDateISO: '2024-03-09' },
+    });
+    const dates = dailyChores.map((chore) => chore.scheduledDate);
+    expect(dates).toEqual(['2024-03-09', '2024-03-10']);
+  });
+
+  it('treats completions near midnight as the correct day boundary', () => {
+    const { dailyChores } = generateCycle(baseState);
+    const target = dailyChores[0];
+    const justBeforeMidnight = completeDailyChore(dailyChores, target.id, new Date('2024-03-09T23:59:59'));
+    const justAfterMidnight = completeDailyChore(dailyChores, target.id, new Date('2024-03-10T00:00:01'));
+    expect(isCompletedToday(justBeforeMidnight.find((c) => c.id === target.id)!, '2024-03-09')).toBe(true);
+    expect(isCompletedToday(justAfterMidnight.find((c) => c.id === target.id)!, '2024-03-09')).toBe(false);
+  });
+
+  it('produces deterministic payouts with a fixed seed', () => {
+    const first = generateCycle(baseState);
+    const second = generateCycle(baseState);
+    expect(first.dailyChores.map((c) => c.finalPayout)).toEqual(
+      second.dailyChores.map((c) => c.finalPayout)
+    );
+  });
+
+  it('rollover job is idempotent', () => {
+    const generated = generateCycle(baseState);
+    const firstRun = rolloverUnearned(
+      generated.currentCycle!,
+      generated.dailyChores,
+      [],
+      '2024-03-09',
+      new Date('2024-03-10T00:00:00Z')
+    );
+    const secondRun = rolloverUnearned(
+      firstRun.cycle,
+      generated.dailyChores,
+      firstRun.rollovers,
+      '2024-03-09',
+      new Date('2024-03-10T00:00:00Z')
+    );
+    expect(secondRun.cycle.rolloverPool).toBe(firstRun.cycle.rolloverPool);
+    expect(secondRun.rollovers.length).toBe(firstRun.rollovers.length);
+  });
+
+  it('transfers rollover pool into the next cycle funding', () => {
+    const generated = generateCycle(baseState);
+    const rolloverApplied = rolloverUnearned(
+      generated.currentCycle!,
+      generated.dailyChores,
+      [],
+      '2024-03-09',
+      new Date('2024-03-10T00:00:00Z')
+    );
+    const priorCycle: CycleState = { ...rolloverApplied.cycle };
+    const nextState: AppState = {
+      ...baseState,
+      currentCycle: priorCycle,
+      dailyRollovers: rolloverApplied.rollovers,
+      config: { ...baseState.config, startDateISO: '2024-04-01', cashPoolTotal: 100 },
+    };
+    const nextCycle = generateCycle(nextState);
+    expect(nextCycle.currentCycle?.rolloverFromPrior).toBeGreaterThan(0);
+    expect(nextCycle.currentCycle?.fundingPool).toBeCloseTo(100 + priorCycle.rolloverPool, 2);
+  });
+});

--- a/questchores/tsconfig.json
+++ b/questchores/tsconfig.json
@@ -10,7 +10,8 @@
     "isolatedModules": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["vitest/globals", "vite/client"]
+    "types": ["vitest/globals", "vite/client"],
+    "noEmit": true
   },
   "include": ["src", "tests", "vite.config.ts"]
 }


### PR DESCRIPTION
## Summary
- extend the core models and persistence to track generated cycle state, daily chore payouts, and logged rollovers
- add a cycle utility module that deterministically seeds per-chore payouts, marks completions without changing rewards, and records daily rollover amounts
- surface the new behaviour in the UI with a Today view that shows today’s chores, fixed payouts, rollover totals, and a rollover logging control
- cover cycle generation, payout immutability, DST boundaries, and rollover idempotency with new tests

## Testing
- npm test -- --run
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d9531f03dc8330bb5af54f9628b78f