### PR TITLE
Seed users without default PINs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Open http://localhost:5173 in your browser. The seed loader populates four demo 
 The seed loader (`useSeedData`) creates:
 
 - 4 example users (Ava, Milo, Nova, Zen) with emoji avatars.
+- Seeded users start without a PIN so the roster is unlocked by default; add one later from **Settings → Household PIN** if desired.
 - 12 quest templates spanning all recurrence types with lore-rich flavour text.
 
 Delete browser storage to re-run the seeding process.

--- a/src/data/seeds.ts
+++ b/src/data/seeds.ts
@@ -3,10 +3,10 @@ import type { CardTemplate, User } from '../types'
 export function createSeedUsers(): User[] {
   const today = new Date().toISOString()
   return [
-    { id: 'ava', name: 'Ava', color: '#FDE68A', avatarEmoji: '🛡️', joinDate: today, isAdult: true, pin: '1111' },
-    { id: 'milo', name: 'Milo', color: '#F9A8D4', avatarEmoji: '🧙', joinDate: today, pin: '2222' },
-    { id: 'nova', name: 'Nova', color: '#93C5FD', avatarEmoji: '🗡️', joinDate: today, pin: '3333' },
-    { id: 'zen', name: 'Zen', color: '#86EFAC', avatarEmoji: '🧝', joinDate: today, pin: '4444' },
+    { id: 'ava', name: 'Ava', color: '#FDE68A', avatarEmoji: '🛡️', joinDate: today, isAdult: true },
+    { id: 'milo', name: 'Milo', color: '#F9A8D4', avatarEmoji: '🧙', joinDate: today },
+    { id: 'nova', name: 'Nova', color: '#93C5FD', avatarEmoji: '🗡️', joinDate: today },
+    { id: 'zen', name: 'Zen', color: '#86EFAC', avatarEmoji: '🧝', joinDate: today },
   ]
 }
 


### PR DESCRIPTION
## Summary
- remove default PIN assignments from seeded users so the roster is unlocked on first launch
- document in the README that seed users begin without a PIN and can add one later from Settings

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68e43f0a30d883308f7e2d2edfa5ece4